### PR TITLE
Fix datetime encoding for locales with accented characters

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 		<script src="vendor/js/mock.js"></script>
 		<script src="config.js"></script>
 		<script src="vendor/js/jquery.min.js"></script>
-		<script src="vendor/js/moment-with-locales.min.js"></script>
+		<script src="vendor/js/moment-with-locales.min.js" charset="UTF-8"></script>
 	</head>
 	<body>
 		<div class="wrap">


### PR DESCRIPTION
Accented letters show up wrong in the datetime section (tested with Slovak locale).

This is an encoding issue, specifying UTF-8 as charset for the Moment.js library fixes it.