### PR TITLE
Fix button alignment

### DIFF
--- a/js/arc.js
+++ b/js/arc.js
@@ -300,7 +300,7 @@ class ArcTheme {
 
 	Initialize_buttons() {
 		if(lightdm.can_shutdown && prefs["allow_shutdown"])
-			$("#shutdown-btn").css("display", "inherit");
+			$("#shutdown-btn").css("display", "block");
 		if(lightdm.can_restart && prefs["allow_restart"])
 			$("#restart-btn").css("display", "block");
 		if(lightdm.can_suspend && prefs["allow_suspend"])


### PR DESCRIPTION
This pull request fixes the alignment of the shutdown button (see screenshot).

![image](https://user-images.githubusercontent.com/15075613/114110179-3173df00-98d7-11eb-8678-7fbb4421df79.png)

vs

![image](https://user-images.githubusercontent.com/15075613/114110222-4fd9da80-98d7-11eb-9512-4891aa000fd6.png)

Fixes #10
